### PR TITLE
bumped libc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ exclude       = [".gitignore"]
 
 [dependencies]
 khronos = "0.1.1"
-libc    = "0.1.10"
+libc    = "0.2.16"


### PR DESCRIPTION
Old version causes hard to debug problems when this crate is used with
other crates requiring newer version.
