### PR TITLE
Add a build.rs script to use pkg_config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ repository    = "https://github.com/seankerr/rust-egl"
 readme        = "README.md"
 keywords      = ["egl", "gl", "khronos", "opengl"]
 exclude       = [".gitignore"]
+build         = "build.rs"
 
 [dependencies]
 khronos = "0.1.1"
 libc    = "0.2.16"
+
+[build-dependencies]
+pkg-config = "0.3.8"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+extern crate pkg_config;
+
+fn main() {
+    pkg_config::Config::new().atleast_version("1").probe("egl").unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,7 @@
 // | See the License for the specific language governing permissions and                           |
 // | limitations under the License.                                                                |
 // +-----------------------------------------------------------------------------------------------+
-// | Authors: Sean Kerr <sean@metatomic.io>                                                        |
-// |          Timothée Haudebourg <author@haudebourg.net>                                          |
+// | Author: Sean Kerr <sean@metatomic.io>                                                         |
 // +-----------------------------------------------------------------------------------------------+
 
 #![crate_name = "egl"]
@@ -34,8 +33,7 @@ use std::ffi::CString;
 use std::ptr;
 
 // system
-use khronos::{ khronos_int32_t,
-               khronos_utime_nanoseconds_t };
+use khronos::khronos_int32_t;
 
 use libc::{ c_uint,
             c_void,
@@ -48,23 +46,23 @@ use libc::{ c_uint,
 #[link(name = "EGL")]
 extern {}
 
-// ------------------------------------------------------------------------------------------------
-// EGL 1.0
-// ------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
+// GLOBAL TYPES
+// -------------------------------------------------------------------------------------------------
 
 pub type EGLBoolean           = c_uint;
-pub type EGLint               = khronos_int32_t;
-pub type EGLDisplay           = *mut c_void;
+pub type EGLClientBuffer      = *mut c_void;
 pub type EGLConfig            = *mut c_void;
 pub type EGLContext           = *mut c_void;
-pub type EGLSurface           = *mut c_void;
+pub type EGLDisplay           = *mut c_void;
+pub type EGLenum              = c_uint;
+pub type EGLint               = khronos_int32_t;
 pub type EGLNativeDisplayType = *mut c_void;
+pub type EGLSurface           = *mut c_void;
 
-#[cfg(not(android))]
-pub type EGLNativePixmapType = *mut c_void;
-
-#[cfg(not(android))]
-pub type EGLNativeWindowType = *mut c_void;
+// -------------------------------------------------------------------------------------------------
+// ANDROID TYPES
+// -------------------------------------------------------------------------------------------------
 
 #[repr(C)]
 #[cfg(android)]
@@ -80,76 +78,222 @@ pub type EGLNativePixmapType = *mut egl_native_pixmap_t;
 #[cfg(android)]
 pub type EGLNativeWindowType = *mut android_native_window_t;
 
+// -------------------------------------------------------------------------------------------------
+// NON-ANDROID TYPES
+// -------------------------------------------------------------------------------------------------
+
+#[cfg(not(android))]
+pub type EGLNativePixmapType = *mut c_void;
+
+#[cfg(not(android))]
+pub type EGLNativeWindowType = *mut c_void;
+
+// -------------------------------------------------------------------------------------------------
+// STRUCTS
+// -------------------------------------------------------------------------------------------------
+
 pub struct EGLConfigList {
-    pub configs: *mut EGLConfig,
+    pub configs: EGLConfig,
     pub count:   int32_t
 }
 
-pub const EGL_ALPHA_SIZE: EGLint = 0x3021;
-pub const EGL_BAD_ACCESS: EGLint = 0x3002;
-pub const EGL_BAD_ALLOC: EGLint = 0x3003;
-pub const EGL_BAD_ATTRIBUTE: EGLint = 0x3004;
-pub const EGL_BAD_CONFIG: EGLint = 0x3005;
-pub const EGL_BAD_CONTEXT: EGLint = 0x3006;
-pub const EGL_BAD_CURRENT_SURFACE: EGLint = 0x3007;
-pub const EGL_BAD_DISPLAY: EGLint = 0x3008;
-pub const EGL_BAD_MATCH: EGLint = 0x3009;
-pub const EGL_BAD_NATIVE_PIXMAP: EGLint = 0x300A;
-pub const EGL_BAD_NATIVE_WINDOW: EGLint = 0x300B;
-pub const EGL_BAD_PARAMETER: EGLint = 0x300C;
-pub const EGL_BAD_SURFACE: EGLint = 0x300D;
-pub const EGL_BLUE_SIZE: EGLint = 0x3022;
-pub const EGL_BUFFER_SIZE: EGLint = 0x3020;
-pub const EGL_CONFIG_CAVEAT: EGLint = 0x3027;
-pub const EGL_CONFIG_ID: EGLint = 0x3028;
-pub const EGL_CORE_NATIVE_ENGINE: EGLint = 0x305B;
-pub const EGL_DEPTH_SIZE: EGLint = 0x3025;
-pub const EGL_DONT_CARE: EGLint = -1;
-pub const EGL_DRAW: EGLint = 0x3059;
-pub const EGL_EXTENSIONS: EGLint = 0x3055;
+// -------------------------------------------------------------------------------------------------
+// CONSTANTS
+// -------------------------------------------------------------------------------------------------
+
+// EGL aliases
 pub const EGL_FALSE: EGLBoolean = 0;
-pub const EGL_GREEN_SIZE: EGLint = 0x3023;
-pub const EGL_HEIGHT: EGLint = 0x3056;
-pub const EGL_LARGEST_PBUFFER: EGLint = 0x3058;
-pub const EGL_LEVEL: EGLint = 0x3029;
-pub const EGL_MAX_PBUFFER_HEIGHT: EGLint = 0x302A;
-pub const EGL_MAX_PBUFFER_PIXELS: EGLint = 0x302B;
-pub const EGL_MAX_PBUFFER_WIDTH: EGLint = 0x302C;
-pub const EGL_NATIVE_RENDERABLE: EGLint = 0x302D;
-pub const EGL_NATIVE_VISUAL_ID: EGLint = 0x302E;
-pub const EGL_NATIVE_VISUAL_TYPE: EGLint = 0x302F;
-pub const EGL_NONE: EGLint = 0x3038;
-pub const EGL_NON_CONFORMANT_CONFIG: EGLint = 0x3051;
-pub const EGL_NOT_INITIALIZED: EGLint = 0x3001;
-pub const EGL_NO_CONTEXT: EGLContext = 0 as EGLContext;
-pub const EGL_NO_DISPLAY: EGLDisplay = 0 as EGLDisplay;
-pub const EGL_NO_SURFACE: EGLSurface = 0 as EGLSurface;
-pub const EGL_PBUFFER_BIT: EGLint = 0x0001;
-pub const EGL_PIXMAP_BIT: EGLint = 0x0002;
-pub const EGL_READ: EGLint = 0x305A;
-pub const EGL_RED_SIZE: EGLint = 0x3024;
-pub const EGL_SAMPLES: EGLint = 0x3031;
-pub const EGL_SAMPLE_BUFFERS: EGLint = 0x3032;
-pub const EGL_SLOW_CONFIG: EGLint = 0x3050;
-pub const EGL_STENCIL_SIZE: EGLint = 0x3026;
-pub const EGL_SUCCESS: EGLint = 0x3000;
-pub const EGL_SURFACE_TYPE: EGLint = 0x3033;
-pub const EGL_TRANSPARENT_BLUE_VALUE: EGLint = 0x3035;
+pub const EGL_TRUE:  EGLBoolean = 1;
+
+// out-of-band handle values
+pub const EGL_DEFAULT_DISPLAY: EGLNativeDisplayType = 0 as *mut c_void;
+pub const EGL_NO_CONTEXT:      EGLContext = 0 as *mut c_void;
+pub const EGL_NO_DISPLAY:      EGLDisplay = 0 as *mut c_void;
+pub const EGL_NO_SURFACE:      EGLSurface = 0 as *mut c_void;
+
+// out-of-band attribute value
+pub const EGL_DONT_CARE: EGLint = -1;
+
+// errors / GetError return values
+pub const EGL_SUCCESS:             EGLint = 0x3000;
+pub const EGL_NOT_INITIALIZED:     EGLint = 0x3001;
+pub const EGL_BAD_ACCESS:          EGLint = 0x3002;
+pub const EGL_BAD_ALLOC:           EGLint = 0x3003;
+pub const EGL_BAD_ATTRIBUTE:       EGLint = 0x3004;
+pub const EGL_BAD_CONFIG:          EGLint = 0x3005;
+pub const EGL_BAD_CONTEXT:         EGLint = 0x3006;
+pub const EGL_BAD_CURRENT_SURFACE: EGLint = 0x3007;
+pub const EGL_BAD_DISPLAY:         EGLint = 0x3008;
+pub const EGL_BAD_MATCH:           EGLint = 0x3009;
+pub const EGL_BAD_NATIVE_PIXMAP:   EGLint = 0x300A;
+pub const EGL_BAD_NATIVE_WINDOW:   EGLint = 0x300B;
+pub const EGL_BAD_PARAMETER:       EGLint = 0x300C;
+pub const EGL_BAD_SURFACE:         EGLint = 0x300D;
+pub const EGL_CONTEXT_LOST:        EGLint = 0x300E;  // EGL 1.1 - IMG_power_management
+
+// config attributes
+pub const EGL_BUFFER_SIZE:             EGLint = 0x3020;
+pub const EGL_ALPHA_SIZE:              EGLint = 0x3021;
+pub const EGL_BLUE_SIZE:               EGLint = 0x3022;
+pub const EGL_GREEN_SIZE:              EGLint = 0x3023;
+pub const EGL_RED_SIZE:                EGLint = 0x3024;
+pub const EGL_DEPTH_SIZE:              EGLint = 0x3025;
+pub const EGL_STENCIL_SIZE:            EGLint = 0x3026;
+pub const EGL_CONFIG_CAVEAT:           EGLint = 0x3027;
+pub const EGL_CONFIG_ID:               EGLint = 0x3028;
+pub const EGL_LEVEL:                   EGLint = 0x3029;
+pub const EGL_MAX_PBUFFER_HEIGHT:      EGLint = 0x302A;
+pub const EGL_MAX_PBUFFER_PIXELS:      EGLint = 0x302B;
+pub const EGL_MAX_PBUFFER_WIDTH:       EGLint = 0x302C;
+pub const EGL_NATIVE_RENDERABLE:       EGLint = 0x302D;
+pub const EGL_NATIVE_VISUAL_ID:        EGLint = 0x302E;
+pub const EGL_NATIVE_VISUAL_TYPE:      EGLint = 0x302F;
+pub const EGL_SAMPLES:                 EGLint = 0x3031;
+pub const EGL_SAMPLE_BUFFERS:          EGLint = 0x3032;
+pub const EGL_SURFACE_TYPE:            EGLint = 0x3033;
+pub const EGL_TRANSPARENT_TYPE:        EGLint = 0x3034;
+pub const EGL_TRANSPARENT_BLUE_VALUE:  EGLint = 0x3035;
 pub const EGL_TRANSPARENT_GREEN_VALUE: EGLint = 0x3036;
-pub const EGL_TRANSPARENT_RED_VALUE: EGLint = 0x3037;
-pub const EGL_TRANSPARENT_RGB: EGLint = 0x3052;
-pub const EGL_TRANSPARENT_TYPE: EGLint = 0x3034;
-pub const EGL_TRUE: EGLBoolean = 1;
-pub const EGL_VENDOR: EGLint = 0x3053;
-pub const EGL_VERSION: EGLint = 0x3054;
-pub const EGL_WIDTH: EGLint = 0x3057;
-pub const EGL_WINDOW_BIT: EGLint = 0x0004;
+pub const EGL_TRANSPARENT_RED_VALUE:   EGLint = 0x3037;
+pub const EGL_NONE:                    EGLint = 0x3038; // attrib list terminator
+pub const EGL_BIND_TO_TEXTURE_RGB:     EGLint = 0x3039;
+pub const EGL_BIND_TO_TEXTURE_RGBA:    EGLint = 0x303A;
+pub const EGL_MIN_SWAP_INTERVAL:       EGLint = 0x303B;
+pub const EGL_MAX_SWAP_INTERVAL:       EGLint = 0x303C;
+pub const EGL_LUMINANCE_SIZE:          EGLint = 0x303D;
+pub const EGL_ALPHA_MASK_SIZE:         EGLint = 0x303E;
+pub const EGL_COLOR_BUFFER_TYPE:       EGLint = 0x303F;
+pub const EGL_RENDERABLE_TYPE:         EGLint = 0x3040;
+pub const EGL_MATCH_NATIVE_PIXMAP:     EGLint = 0x3041;  // psseudo-attribute (not queryable)
+pub const EGL_CONFORMANT:              EGLint = 0x3042;
+
+// config attribute values
+pub const EGL_SLOW_CONFIG:           EGLint = 0x3050;  // CONFIG_CAVEAT value
+pub const EGL_NON_CONFORMANT_CONFIG: EGLint = 0x3051;  // CONFIG_CAVEAT value
+pub const EGL_TRANSPARENT_RGB:       EGLint = 0x3052;  // TRANSPARENT_TYPE value
+pub const EGL_RGB_BUFFER:            EGLint = 0x308E;  // COLOR_BUFFER_TYPE value
+pub const EGL_LUMINANCE_BUFFER:      EGLint = 0x308F;  // COLOR_BUFFER_TYPE value
+
+// more config attribute values, for TEXTURE_FORMAT
+pub const EGL_NO_TEXTURE:   EGLint = 0x305C;
+pub const EGL_TEXTURE_RGB:  EGLint = 0x305D;
+pub const EGL_TEXTURE_RGBA: EGLint = 0x305E;
+pub const EGL_TEXTURE_2D:   EGLint = 0x305F;
+
+// config attribute mask bits
+pub const EGL_PBUFFER_BIT:                 EGLint = 0x0001;  // SURFACE_TYPE mask bits
+pub const EGL_PIXMAP_BIT:                  EGLint = 0x0002;  // SURFACE_TYPE mask bits
+pub const EGL_WINDOW_BIT:                  EGLint = 0x0004;  // SURFACE_TYPE mask bits
+pub const EGL_VG_COLORSPACE_LINEAR_BIT:    EGLint = 0x0020;  // SURFACE_TYPE mask bits
+pub const EGL_VG_ALPHA_FORMAT_PRE_BIT:     EGLint = 0x0040;  // SURFACE_TYPE mask bits
+pub const EGL_MULTISAMPLE_RESOLVE_BOX_BIT: EGLint = 0x0200;  // SURFACE_TYPE mask bits
+pub const EGL_SWAP_BEHAVIOR_PRESERVED_BIT: EGLint = 0x0400;  // SURFACE_TYPE mask bits
+
+pub const EGL_OPENGL_ES_BIT:  EGLint = 0x0001; // RENDERABLE_TYPE mask bits
+pub const EGL_OPENVG_BIT:     EGLint = 0x0002; // RENDERABLE_TYPE mask bits
+pub const EGL_OPENGL_ES2_BIT: EGLint = 0x0004; // RENDERABLE_TYPE mask bits
+pub const EGL_OPENGL_BIT:     EGLint = 0x0008; // RENDERABLE_TYPE mask bits
+
+// QueryString targets
+pub const EGL_VENDOR:      EGLint = 0x3053;
+pub const EGL_VERSION:     EGLint = 0x3054;
+pub const EGL_EXTENSIONS:  EGLint = 0x3055;
+pub const EGL_CLIENT_APIS: EGLint = 0x308D;
+
+// QuerySurface / SurfaceAttrib / CreatePbufferSurface targets
+pub const EGL_HEIGHT:                EGLint = 0x3056;
+pub const EGL_WIDTH:                 EGLint = 0x3057;
+pub const EGL_LARGEST_PBUFFER:       EGLint = 0x3058;
+pub const EGL_TEXTURE_FORMAT:        EGLint = 0x3080;
+pub const EGL_TEXTURE_TARGET:        EGLint = 0x3081;
+pub const EGL_MIPMAP_TEXTURE:        EGLint = 0x3082;
+pub const EGL_MIPMAP_LEVEL:          EGLint = 0x3083;
+pub const EGL_RENDER_BUFFER:         EGLint = 0x3086;
+pub const EGL_VG_COLORSPACE:         EGLint = 0x3087;
+pub const EGL_VG_ALPHA_FORMAT:       EGLint = 0x3088;
+pub const EGL_HORIZONTAL_RESOLUTION: EGLint = 0x3090;
+pub const EGL_VERTICAL_RESOLUTION:   EGLint = 0x3091;
+pub const EGL_PIXEL_ASPECT_RATIO:    EGLint = 0x3092;
+pub const EGL_SWAP_BEHAVIOR:         EGLint = 0x3093;
+pub const EGL_MULTISAMPLE_RESOLVE:   EGLint = 0x3099;
+
+// RENDER_BUFFER values / BindTexImage / ReleaseTexImage buffer targets
+pub const EGL_BACK_BUFFER:   EGLint = 0x3084;
+pub const EGL_SINGLE_BUFFER: EGLint = 0x3085;
+
+// OpenVG color spaces */
+pub const EGL_VG_COLORSPACE_sRGB:   EGLint = 0x3089;  // VG_COLORSPACE value
+pub const EGL_VG_COLORSPACE_LINEAR: EGLint = 0x308A;  // VG_COLORSPACE value
+
+// OpenVG alpha formats
+pub const EGL_VG_ALPHA_FORMAT_NONPRE: EGLint = 0x308B; // ALPHA_FORMAT value
+pub const EGL_VG_ALPHA_FORMAT_PRE:    EGLint = 0x308C; // ALPHA_FORMAT value
+
+// constant scale factor by which fractional display resolutions & aspect ratio are scaled when
+// queried as integer values
+pub const EGL_DISPLAY_SCALING: EGLint = 10000;
+
+// unknown display resolution/aspect ratio
+pub const EGL_UNKNOWN: EGLint = -1;
+
+// back buffer swap behaviors
+pub const EGL_BUFFER_PRESERVED: EGLint = 0x3094; // SWAP_BEHAVIOR value
+pub const EGL_BUFFER_DESTROYED: EGLint = 0x3095; // SWAP_BEHAVIOR value
+
+// CreatePbufferFromClientBuffer buffer types
+pub const EGL_OPENVG_IMAGE: EGLint = 0x3096;
+
+// QueryContext targets
+pub const EGL_CONTEXT_CLIENT_TYPE: EGLint = 0x3097;
+
+// CreateContext attributes
+pub const EGL_CONTEXT_CLIENT_VERSION: EGLint = 0x3098;
+
+// multisample resolution behaviors
+pub const EGL_MULTISAMPLE_RESOLVE_DEFAULT: EGLint = 0x309A; // MULTISAMPLE_RESOLVE value
+pub const EGL_MULTISAMPLE_RESOLVE_BOX:     EGLint = 0x309B; // MULTISAMPLE_RESOLVE value
+
+// BindAPI/QueryAPI targets
+pub const EGL_OPENGL_ES_API: EGLenum = 0x30A0;
+pub const EGL_OPENVG_API:    EGLenum = 0x30A1;
+pub const EGL_OPENGL_API:    EGLenum = 0x30A2;
+
+// GetCurrentSurface targets
+pub const EGL_DRAW: EGLint = 0x3059;
+pub const EGL_READ: EGLint = 0x305A;
+
+// WaitNative engines
+pub const EGL_CORE_NATIVE_ENGINE: EGLint = 0x305B;
+
+// EGL 1.2 tokens renamed for consistency in EGL 1.3
+pub const EGL_COLORSPACE:          EGLint = EGL_VG_COLORSPACE;
+pub const EGL_ALPHA_FORMAT:        EGLint = EGL_VG_ALPHA_FORMAT;
+pub const EGL_COLORSPACE_sRGB:     EGLint = EGL_VG_COLORSPACE_sRGB;
+pub const EGL_COLORSPACE_LINEAR:   EGLint = EGL_VG_COLORSPACE_LINEAR;
+pub const EGL_ALPHA_FORMAT_NONPRE: EGLint = EGL_VG_ALPHA_FORMAT_NONPRE;
+pub const EGL_ALPHA_FORMAT_PRE:    EGLint = EGL_VG_ALPHA_FORMAT_PRE;
+
+// -------------------------------------------------------------------------------------------------
+// FUNCTIONS
+// -------------------------------------------------------------------------------------------------
+
+pub fn bind_api(api: EGLenum) -> bool {
+    unsafe {
+        ffi::eglBindAPI(api) == EGL_TRUE
+    }
+}
+
+pub fn bind_tex_image(display: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> bool {
+    unsafe {
+        ffi::eglBindTexImage(display, surface, buffer) == EGL_TRUE
+    }
+}
 
 pub fn choose_config(display: EGLDisplay, attrib_list: &[EGLint],
                      config_size: EGLint) -> Option<EGLConfig> {
     unsafe {
         let mut config: EGLConfig = ptr::null_mut();
-        let mut count:  EGLint = 0;;
+        let mut count:  EGLint = 0;
 
         let attribs = if attrib_list.len() > 0 {
             attrib_list.as_ptr()
@@ -190,6 +334,27 @@ pub fn create_context(display: EGLDisplay, config: EGLConfig, share_context: EGL
 
         if !context.is_null() {
             Some(context)
+        } else {
+            None
+        }
+    }
+}
+
+pub fn create_pbuffer_from_client_buffer(display: EGLDisplay, buffer_type: EGLenum,
+                                         buffer: EGLClientBuffer, config: EGLConfig,
+                                         attrib_list: &[EGLint]) -> Option<EGLSurface> {
+    unsafe {
+        let attribs = if attrib_list.len() > 0 {
+            attrib_list.as_ptr()
+        } else {
+            ptr::null()
+        };
+
+        let surface = ffi::eglCreatePbufferFromClientBuffer(display, buffer_type, buffer, config,
+                                                            attribs);
+
+        if !surface.is_null() {
+            Some(surface)
         } else {
             None
         }
@@ -285,6 +450,18 @@ pub fn get_configs(display: EGLDisplay, config_size: EGLint) -> EGLConfigList {
     }
 }
 
+pub fn get_current_context() -> Option<EGLContext> {
+    unsafe {
+        let context = ffi::eglGetCurrentContext();
+
+        if !context.is_null() {
+            Some(context)
+        } else {
+            None
+        }
+    }
+}
+
 pub fn get_current_display() -> Option<EGLDisplay> {
     unsafe {
         let display = ffi::eglGetCurrentDisplay();
@@ -348,6 +525,12 @@ pub fn make_current(display: EGLDisplay, draw: EGLSurface,
     }
 }
 
+pub fn query_api() -> EGLenum {
+    unsafe {
+        ffi::eglQueryAPI()
+    }
+}
+
 pub fn query_context(display: EGLDisplay, ctx: EGLContext,
                      attribute: EGLint, value: &mut EGLint) -> bool {
     unsafe {
@@ -374,15 +557,46 @@ pub fn query_surface(display: EGLDisplay, surface: EGLSurface,
     }
 }
 
+pub fn release_tex_image(display: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> bool {
+    unsafe {
+        ffi::eglReleaseTexImage(display, surface, buffer) == EGL_TRUE
+    }
+}
+
+pub fn release_thread() -> bool {
+    unsafe {
+        ffi::eglReleaseThread() == EGL_TRUE
+    }
+}
+
+pub fn surface_attrib(display: EGLDisplay, surface: EGLSurface,
+                      attribute: EGLint, value: EGLint) -> bool {
+    unsafe {
+        ffi::eglSurfaceAttrib(display, surface, attribute, value) == EGL_TRUE
+    }
+}
+
 pub fn swap_buffers(display: EGLDisplay, surface: EGLSurface) -> bool {
     unsafe {
         ffi::eglSwapBuffers(display, surface) == EGL_TRUE
     }
 }
 
+pub fn swap_interval(display: EGLDisplay, interval: EGLint) -> bool {
+    unsafe {
+        ffi::eglSwapInterval(display, interval) == EGL_TRUE
+    }
+}
+
 pub fn terminate(display: EGLDisplay) -> bool {
     unsafe {
         ffi::eglTerminate(display) == EGL_TRUE
+    }
+}
+
+pub fn wait_client() -> bool {
+    unsafe {
+        ffi::eglWaitClient() == EGL_TRUE
     }
 }
 
@@ -398,354 +612,12 @@ pub fn wait_native(engine: EGLint) -> bool {
     }
 }
 
-// ------------------------------------------------------------------------------------------------
-// EGL 1.1
-// ------------------------------------------------------------------------------------------------
-
-pub const EGL_BACK_BUFFER: EGLint = 0x3084;
-pub const EGL_BIND_TO_TEXTURE_RGB: EGLint = 0x3039;
-pub const EGL_BIND_TO_TEXTURE_RGBA: EGLint = 0x303A;
-pub const EGL_CONTEXT_LOST: EGLint = 0x300E;
-pub const EGL_MIN_SWAP_INTERVAL: EGLint = 0x303B;
-pub const EGL_MAX_SWAP_INTERVAL: EGLint = 0x303C;
-pub const EGL_MIPMAP_TEXTURE: EGLint = 0x3082;
-pub const EGL_MIPMAP_LEVEL: EGLint = 0x3083;
-pub const EGL_NO_TEXTURE: EGLint = 0x305C;
-pub const EGL_TEXTURE_2D: EGLint = 0x305F;
-pub const EGL_TEXTURE_FORMAT: EGLint = 0x3080;
-pub const EGL_TEXTURE_RGB: EGLint = 0x305D;
-pub const EGL_TEXTURE_RGBA: EGLint = 0x305E;
-pub const EGL_TEXTURE_TARGET: EGLint = 0x3081;
-
-pub fn bind_tex_image(display: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> bool {
-    unsafe {
-        ffi::eglBindTexImage(display, surface, buffer) == EGL_TRUE
-    }
-}
-
-pub fn release_tex_image(display: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> bool {
-    unsafe {
-        ffi::eglReleaseTexImage(display, surface, buffer) == EGL_TRUE
-    }
-}
-
-pub fn surface_attrib(display: EGLDisplay, surface: EGLSurface,
-                      attribute: EGLint, value: EGLint) -> bool {
-    unsafe {
-        ffi::eglSurfaceAttrib(display, surface, attribute, value) == EGL_TRUE
-    }
-}
-
-pub fn swap_interval(display: EGLDisplay, interval: EGLint) -> bool {
-    unsafe {
-        ffi::eglSwapInterval(display, interval) == EGL_TRUE
-    }
-}
-
-// ------------------------------------------------------------------------------------------------
-// EGL 1.2
-// ------------------------------------------------------------------------------------------------
-
-pub type EGLenum              = c_uint;
-pub type EGLClientBuffer      = *mut c_void;
-
-pub const EGL_ALPHA_FORMAT: EGLint = 0x3088;
-pub const EGL_ALPHA_FORMAT_NONPRE: EGLint = 0x308B;
-pub const EGL_ALPHA_FORMAT_PRE: EGLint = 0x308C;
-pub const EGL_ALPHA_MASK_SIZE: EGLint = 0x303E;
-pub const EGL_BUFFER_PRESERVED: EGLint = 0x3094;
-pub const EGL_BUFFER_DESTROYED: EGLint = 0x3095;
-pub const EGL_CLIENT_APIS: EGLint = 0x308D;
-pub const EGL_COLORSPACE: EGLint = 0x3087;
-pub const EGL_COLORSPACE_sRGB: EGLint = 0x3089;
-pub const EGL_COLORSPACE_LINEAR: EGLint = 0x308A;
-pub const EGL_COLOR_BUFFER_TYPE: EGLint = 0x303F;
-pub const EGL_CONTEXT_CLIENT_TYPE: EGLint = 0x3097;
-pub const EGL_DISPLAY_SCALING: EGLint = 10000;
-pub const EGL_HORIZONTAL_RESOLUTION: EGLint = 0x3090;
-pub const EGL_LUMINANCE_BUFFER: EGLint = 0x308F;
-pub const EGL_LUMINANCE_SIZE: EGLint = 0x303D;
-pub const EGL_OPENGL_ES_BIT: EGLint = 0x0001;
-pub const EGL_OPENVG_BIT: EGLint = 0x0002;
-pub const EGL_OPENGL_ES_API: EGLint = 0x30A0;
-pub const EGL_OPENVG_API: EGLint = 0x30A1;
-pub const EGL_OPENVG_IMAGE: EGLint = 0x3096;
-pub const EGL_PIXEL_ASPECT_RATIO: EGLint = 0x3092;
-pub const EGL_RENDERABLE_TYPE: EGLint = 0x3040;
-pub const EGL_RENDER_BUFFER: EGLint = 0x3086;
-pub const EGL_RGB_BUFFER: EGLint = 0x308E;
-pub const EGL_SINGLE_BUFFER: EGLint = 0x3085;
-pub const EGL_SWAP_BEHAVIOR: EGLint = 0x3093;
-pub const EGL_UNKNOWN: EGLint = -1;
-pub const EGL_VERTICAL_RESOLUTION: EGLint = 0x3091;
-
-pub fn bind_api(api: EGLenum) -> bool {
-    unsafe {
-        ffi::eglBindAPI(api) == EGL_TRUE
-    }
-}
-
-pub fn query_api() -> EGLenum {
-    unsafe {
-        ffi::eglQueryAPI()
-    }
-}
-
-pub fn create_pbuffer_from_client_buffer(display: EGLDisplay, buffer_type: EGLenum,
-                                         buffer: EGLClientBuffer, config: EGLConfig,
-                                         attrib_list: &[EGLint]) -> Option<EGLSurface> {
-    unsafe {
-        let attribs = if attrib_list.len() > 0 {
-            attrib_list.as_ptr()
-        } else {
-            ptr::null()
-        };
-
-        let surface = ffi::eglCreatePbufferFromClientBuffer(display, buffer_type, buffer, config,
-                                                            attribs);
-
-        if !surface.is_null() {
-            Some(surface)
-        } else {
-            None
-        }
-    }
-}
-
-pub fn release_thread() -> bool {
-    unsafe {
-        ffi::eglReleaseThread() == EGL_TRUE
-    }
-}
-
-pub fn wait_client() -> bool {
-    unsafe {
-        ffi::eglWaitClient() == EGL_TRUE
-    }
-}
-
-// ------------------------------------------------------------------------------------------------
-// EGL 1.3
-// ------------------------------------------------------------------------------------------------
-
-pub const EGL_CONFORMANT: EGLint = 0x3042;
-pub const EGL_CONTEXT_CLIENT_VERSION: EGLint = 0x3098;
-pub const EGL_MATCH_NATIVE_PIXMAP: EGLint = 0x3041;
-pub const EGL_OPENGL_ES2_BIT: EGLint = 0x0004;
-pub const EGL_VG_ALPHA_FORMAT: EGLint = 0x3088;
-pub const EGL_VG_ALPHA_FORMAT_NONPRE: EGLint = 0x308B;
-pub const EGL_VG_ALPHA_FORMAT_PRE: EGLint = 0x308C;
-pub const EGL_VG_ALPHA_FORMAT_PRE_BIT: EGLint = 0x0040;
-pub const EGL_VG_COLORSPACE: EGLint = 0x3087;
-pub const EGL_VG_COLORSPACE_sRGB: EGLint = 0x3089;
-pub const EGL_VG_COLORSPACE_LINEAR: EGLint = 0x308A;
-pub const EGL_VG_COLORSPACE_LINEAR_BIT: EGLint = 0x0020;
-
-// ------------------------------------------------------------------------------------------------
-// EGL 1.4
-// ------------------------------------------------------------------------------------------------
-
-pub const EGL_DEFAULT_DISPLAY: EGLNativeDisplayType = 0 as EGLNativeDisplayType;
-pub const EGL_MULTISAMPLE_RESOLVE_BOX_BIT: EGLint = 0x0200;
-pub const EGL_MULTISAMPLE_RESOLVE: EGLint = 0x3099;
-pub const EGL_MULTISAMPLE_RESOLVE_DEFAULT: EGLint = 0x309A;
-pub const EGL_MULTISAMPLE_RESOLVE_BOX: EGLint = 0x309B;
-pub const EGL_OPENGL_API: EGLint = 0x30A2;
-pub const EGL_OPENGL_BIT: EGLint = 0x0008;
-pub const EGL_SWAP_BEHAVIOR_PRESERVED_BIT: EGLint = 0x0400;
-
-pub fn get_current_context() -> Option<EGLContext> {
-    unsafe {
-        let context = ffi::eglGetCurrentContext();
-
-        if !context.is_null() {
-            Some(context)
-        } else {
-            None
-        }
-    }
-}
-
-// ------------------------------------------------------------------------------------------------
-// EGL 1.5
-// ------------------------------------------------------------------------------------------------
-
-pub type EGLSync              = *mut c_void;
-pub type EGLAttrib            = usize;
-pub type EGLTime              = khronos_utime_nanoseconds_t;
-pub type EGLImage             = *mut c_void;
-
-pub const EGL_CONTEXT_MAJOR_VERSION: EGLint = 0x3098;
-pub const EGL_CONTEXT_MINOR_VERSION: EGLint = 0x30FB;
-pub const EGL_CONTEXT_OPENGL_PROFILE_MASK: EGLint = 0x30FD;
-pub const EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY: EGLint = 0x31BD;
-pub const EGL_NO_RESET_NOTIFICATION: EGLint = 0x31BE;
-pub const EGL_LOSE_CONTEXT_ON_RESET: EGLint = 0x31BF;
-pub const EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT: EGLint = 0x00000001;
-pub const EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT: EGLint = 0x00000002;
-pub const EGL_CONTEXT_OPENGL_DEBUG: EGLint = 0x31B0;
-pub const EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE: EGLint = 0x31B1;
-pub const EGL_CONTEXT_OPENGL_ROBUST_ACCESS: EGLint = 0x31B2;
-pub const EGL_OPENGL_ES3_BIT: EGLint = 0x00000040;
-pub const EGL_CL_EVENT_HANDLE: EGLint = 0x309C;
-pub const EGL_SYNC_CL_EVENT: EGLint = 0x30FE;
-pub const EGL_SYNC_CL_EVENT_COMPLETE: EGLint = 0x30FF;
-pub const EGL_SYNC_PRIOR_COMMANDS_COMPLETE: EGLint = 0x30F0;
-pub const EGL_SYNC_TYPE: EGLint = 0x30F7;
-pub const EGL_SYNC_STATUS: EGLint = 0x30F1;
-pub const EGL_SYNC_CONDITION: EGLint = 0x30F8;
-pub const EGL_SIGNALED: EGLint = 0x30F2;
-pub const EGL_UNSIGNALED: EGLint = 0x30F3;
-pub const EGL_SYNC_FLUSH_COMMANDS_BIT: EGLint = 0x0001;
-pub const EGL_FOREVER: u64 = 0xFFFFFFFFFFFFFFFFu64;
-pub const EGL_TIMEOUT_EXPIRED: EGLint = 0x30F5;
-pub const EGL_CONDITION_SATISFIED: EGLint = 0x30F6;
-pub const EGL_NO_SYNC: EGLSync = 0 as EGLSync;
-pub const EGL_SYNC_FENCE: EGLint = 0x30F9;
-pub const EGL_GL_COLORSPACE: EGLint = 0x309D;
-pub const EGL_GL_COLORSPACE_SRGB: EGLint = 0x3089;
-pub const EGL_GL_COLORSPACE_LINEAR: EGLint = 0x308A;
-pub const EGL_GL_RENDERBUFFER: EGLint = 0x30B9;
-pub const EGL_GL_TEXTURE_2D: EGLint = 0x30B1;
-pub const EGL_GL_TEXTURE_LEVEL: EGLint = 0x30BC;
-pub const EGL_GL_TEXTURE_3D: EGLint = 0x30B2;
-pub const EGL_GL_TEXTURE_ZOFFSET: EGLint = 0x30BD;
-pub const EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_X: EGLint = 0x30B3;
-pub const EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_X: EGLint = 0x30B4;
-pub const EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Y: EGLint = 0x30B5;
-pub const EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Y: EGLint = 0x30B6;
-pub const EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Z: EGLint = 0x30B7;
-pub const EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Z: EGLint = 0x30B8;
-pub const EGL_IMAGE_PRESERVED: EGLint = 0x30D2;
-pub const EGL_NO_IMAGE: EGLImage = 0 as EGLImage;
-
-pub fn create_sync(dpy: EGLDisplay, ty: EGLenum, attrib_list: &[EGLAttrib]) -> Option<EGLSync> {
-    let attribs = if attrib_list.len() > 0 {
-        attrib_list.as_ptr()
-    } else {
-        ptr::null()
-    };
-
-    unsafe {
-        let sync = ffi::eglCreateSync(dpy, ty, attribs);
-        if sync.is_null() {
-            None
-        } else {
-            Some(sync)
-        }
-    }
-}
-
-pub fn destroy_sync(dpy: EGLDisplay, sync: EGLSync) -> bool {
-    unsafe {
-        ffi::eglDestroySync(dpy, sync) == EGL_TRUE
-    }
-}
-
-pub fn client_wait_sync(dpy: EGLDisplay, sync: EGLSync, flags: EGLint, timeout: EGLTime) -> EGLint {
-    unsafe {
-        ffi::eglClientWaitSync(dpy, sync, flags, timeout)
-    }
-}
-
-pub fn get_sync_attrib(dpy: EGLDisplay, sync: EGLSync, attribute: EGLint) -> Option<EGLAttrib> {
-    unsafe {
-        let mut value = 0;
-        if ffi::eglGetSyncAttrib(dpy, sync, attribute, &mut value as *mut EGLAttrib) == EGL_TRUE {
-            None
-        } else {
-            Some(value)
-        }
-    }
-}
-
-pub fn create_image(dpy: EGLDisplay, ctx: EGLContext, target: EGLenum, buffer: EGLClientBuffer, attrib_list: &[EGLAttrib]) -> Option<EGLImage> {
-    let attribs = if attrib_list.len() > 0 {
-        attrib_list.as_ptr()
-    } else {
-        ptr::null()
-    };
-
-    unsafe {
-        let image = ffi::eglCreateImage(dpy, ctx, target, buffer, attribs);
-        if image.is_null() {
-            None
-        } else {
-            Some(image)
-        }
-    }
-}
-
-pub fn destroy_image(dpy: EGLDisplay, image: EGLImage) -> bool {
-    unsafe {
-        ffi::eglDestroyImage(dpy, image) == EGL_TRUE
-    }
-}
-
-pub fn get_platform_display(platform: EGLenum, native_display: *mut c_void, attrib_list: &[EGLAttrib]) -> Option<EGLDisplay> {
-    let attribs = if attrib_list.len() > 0 {
-        attrib_list.as_ptr()
-    } else {
-        ptr::null()
-    };
-
-    unsafe {
-        let display = ffi::eglGetPlatformDisplay(platform, native_display, attribs);
-        if display.is_null() {
-            None
-        } else {
-            Some(display)
-        }
-    }
-}
-
-pub fn create_platform_window_surface(dpy: EGLDisplay, config: EGLConfig, native_window: *mut c_void, attrib_list: &[EGLAttrib]) -> Option<EGLSurface> {
-    let attribs = if attrib_list.len() > 0 {
-        attrib_list.as_ptr()
-    } else {
-        ptr::null()
-    };
-
-    unsafe {
-        let surface = ffi::eglCreatePlatformWindowSurface(dpy, config, native_window, attribs);
-        if surface.is_null() {
-            None
-        } else {
-            Some(surface)
-        }
-    }
-}
-
-pub fn create_platform_pixmap_surface(dpy: EGLDisplay, config: EGLConfig, native_pixmap: *mut c_void, attrib_list: &[EGLAttrib]) -> Option<EGLSurface> {
-    let attribs = if attrib_list.len() > 0 {
-        attrib_list.as_ptr()
-    } else {
-        ptr::null()
-    };
-
-    unsafe {
-        let surface = ffi::eglCreatePlatformPixmapSurface(dpy, config, native_pixmap, attribs);
-        if surface.is_null() {
-            None
-        } else {
-            Some(surface)
-        }
-    }
-}
-
-pub fn wait_sync(dpy: EGLDisplay, sync: EGLSync, flags: EGLint) -> bool {
-    unsafe {
-        ffi::eglWaitSync(dpy, sync, flags) == EGL_TRUE
-    }
-}
-
 // -------------------------------------------------------------------------------------------------
 // FFI
 // -------------------------------------------------------------------------------------------------
 
 mod ffi {
-    use libc::{ c_char,
-                c_void };
+    use libc::c_char;
 
     use super::{ EGLBoolean,
                  EGLClientBuffer,
@@ -757,65 +629,94 @@ mod ffi {
                  EGLNativeDisplayType,
                  EGLNativePixmapType,
                  EGLNativeWindowType,
-                 EGLSurface,
-                 EGLAttrib,
-                 EGLSync,
-                 EGLTime,
-                 EGLImage };
+                 EGLSurface };
 
     extern {
-        // EGL 1.0
-        pub fn eglChooseConfig(dpy: EGLDisplay, attrib_list: *const EGLint, configs: *mut EGLConfig, config_size: EGLint, num_config: *mut EGLint) -> EGLBoolean;
-        pub fn eglCopyBuffers(dpy: EGLDisplay, surface: EGLSurface, target: EGLNativePixmapType) -> EGLBoolean;
-        pub fn eglCreateContext(dpy: EGLDisplay, config: EGLConfig, share_context: EGLContext, attrib_list: *const EGLint) -> EGLContext;
-        pub fn eglCreatePbufferSurface(dpy: EGLDisplay, config: EGLConfig, attrib_list: *const EGLint) -> EGLSurface;
-        pub fn eglCreatePixmapSurface(dpy: EGLDisplay, config: EGLConfig, pixmap: EGLNativePixmapType, attrib_list: *const EGLint) -> EGLSurface;
-        pub fn eglCreateWindowSurface(dpy: EGLDisplay, config: EGLConfig, win: EGLNativeWindowType, attrib_list: *const EGLint) -> EGLSurface;
-        pub fn eglDestroyContext(dpy: EGLDisplay, ctx: EGLContext) -> EGLBoolean;
-        pub fn eglDestroySurface(dpy: EGLDisplay, surface: EGLSurface) -> EGLBoolean;
-        pub fn eglGetConfigAttrib(dpy: EGLDisplay, config: EGLConfig, attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
-        pub fn eglGetConfigs(dpy: EGLDisplay, configs: *mut EGLConfig, config_size: EGLint, num_config: *mut EGLint) -> EGLBoolean;
-        pub fn eglGetCurrentDisplay() -> EGLDisplay;
-        pub fn eglGetCurrentSurface(readdraw: EGLint) -> EGLSurface;
-        pub fn eglGetDisplay(display_id: EGLNativeDisplayType) -> EGLDisplay;
-        pub fn eglGetError() -> EGLint;
-        pub fn eglGetProcAddress(procname: *const c_char) -> extern "C" fn();
-        pub fn eglInitialize(dpy: EGLDisplay, major: *mut EGLint, minor: *mut EGLint) -> EGLBoolean;
-        pub fn eglMakeCurrent(dpy: EGLDisplay, draw: EGLSurface, read: EGLSurface, ctx: EGLContext) -> EGLBoolean;
-        pub fn eglQueryContext(dpy: EGLDisplay, ctx: EGLContext, attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
-        pub fn eglQueryString(dpy: EGLDisplay, name: EGLint) -> *const c_char;
-        pub fn eglQuerySurface(dpy: EGLDisplay, surface: EGLSurface, attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
-        pub fn eglSwapBuffers(dpy: EGLDisplay, surface: EGLSurface) -> EGLBoolean;
-        pub fn eglTerminate(dpy: EGLDisplay) -> EGLBoolean;
-        pub fn eglWaitGL() -> EGLBoolean;
-        pub fn eglWaitNative(engine: EGLint) -> EGLBoolean;
-
-        // EGL 1.1
-        pub fn eglBindTexImage(dpy: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> EGLBoolean;
-        pub fn eglReleaseTexImage(dpy: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> EGLBoolean;
-        pub fn eglSurfaceAttrib(dpy: EGLDisplay, surface: EGLSurface, attribute: EGLint, value: EGLint) -> EGLBoolean;
-        pub fn eglSwapInterval(dpy: EGLDisplay, interval: EGLint) -> EGLBoolean;
-
-        // EGL 1.2
         pub fn eglBindAPI(api: EGLenum) -> EGLBoolean;
-        pub fn eglQueryAPI() -> EGLenum;
-        pub fn eglCreatePbufferFromClientBuffer(dpy: EGLDisplay, buftype: EGLenum, buffer: EGLClientBuffer, config: EGLConfig, attrib_list: *const EGLint) -> EGLSurface;
-        pub fn eglReleaseThread() -> EGLBoolean;
-        pub fn eglWaitClient() -> EGLBoolean;
 
-        // EGL 1.4
+        pub fn eglBindTexImage(dpy: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> EGLBoolean;
+
+        pub fn eglChooseConfig(dpy: EGLDisplay, attrib_list: *const EGLint,
+                               configs: *mut EGLConfig, config_size: EGLint,
+                               num_config: *mut EGLint) -> EGLBoolean;
+
+        pub fn eglCopyBuffers(dpy: EGLDisplay, surface: EGLSurface,
+                              target: EGLNativePixmapType) -> EGLBoolean;
+
+        pub fn eglCreateContext(dpy: EGLDisplay, config: EGLConfig,
+                                share_context: EGLContext,
+                                attrib_list: *const EGLint) -> EGLContext;
+
+        pub fn eglCreatePbufferFromClientBuffer(dpy: EGLDisplay, buftype: EGLenum,
+                                                buffer: EGLClientBuffer, config: EGLConfig,
+                                                attrib_list: *const EGLint) -> EGLSurface;
+
+        pub fn eglCreatePbufferSurface(dpy: EGLDisplay, config: EGLConfig,
+                                       attrib_list: *const EGLint) -> EGLSurface;
+
+        pub fn eglCreatePixmapSurface(dpy: EGLDisplay, config: EGLConfig,
+                                      pixmap: EGLNativePixmapType,
+                                      attrib_list: *const EGLint) -> EGLSurface;
+
+        pub fn eglCreateWindowSurface(dpy: EGLDisplay, config: EGLConfig,
+                                      win: EGLNativeWindowType,
+                                      attrib_list: *const EGLint) -> EGLSurface;
+
+        pub fn eglDestroyContext(dpy: EGLDisplay, ctx: EGLContext) -> EGLBoolean;
+
+        pub fn eglDestroySurface(dpy: EGLDisplay, surface: EGLSurface) -> EGLBoolean;
+
+        pub fn eglGetConfigAttrib(dpy: EGLDisplay, config: EGLConfig,
+                                  attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
+
+        pub fn eglGetConfigs(dpy: EGLDisplay, configs: EGLConfig,
+                             config_size: EGLint, num_config: *mut EGLint) -> EGLBoolean;
+
         pub fn eglGetCurrentContext() -> EGLContext;
 
-        // EGL 1.5
-        pub fn eglCreateSync(dpy: EGLDisplay, type_: EGLenum, attrib_list: *const EGLAttrib) -> EGLSync;
-        pub fn eglDestroySync(dpy: EGLDisplay, sync: EGLSync) -> EGLBoolean;
-        pub fn eglClientWaitSync(dpy: EGLDisplay, sync: EGLSync, flags: EGLint, timeout: EGLTime) -> EGLint;
-        pub fn eglGetSyncAttrib(dpy: EGLDisplay, sync: EGLSync, attribute: EGLint, value: *mut EGLAttrib) -> EGLBoolean;
-        pub fn eglCreateImage(dpy: EGLDisplay, ctx: EGLContext, target: EGLenum, buffer: EGLClientBuffer, attrib_list: *const EGLAttrib) -> EGLImage;
-        pub fn eglDestroyImage(dpy: EGLDisplay, image: EGLImage) -> EGLBoolean;
-        pub fn eglGetPlatformDisplay(platform: EGLenum, native_display: *mut c_void, attrib_list: *const EGLAttrib) -> EGLDisplay;
-        pub fn eglCreatePlatformWindowSurface(dpy: EGLDisplay, config: EGLConfig, native_window: *mut c_void, attrib_list: *const EGLAttrib) -> EGLSurface;
-        pub fn eglCreatePlatformPixmapSurface(dpy: EGLDisplay, config: EGLConfig, native_pixmap: *mut c_void, attrib_list: *const EGLAttrib) -> EGLSurface;
-        pub fn eglWaitSync(dpy: EGLDisplay, sync: EGLSync, flags: EGLint) -> EGLBoolean;
+        pub fn eglGetCurrentDisplay() -> EGLDisplay;
+
+        pub fn eglGetCurrentSurface(readdraw: EGLint) -> EGLSurface;
+
+        pub fn eglGetDisplay(display_id: EGLNativeDisplayType) -> EGLDisplay;
+
+        pub fn eglGetError() -> EGLint;
+
+        pub fn eglGetProcAddress(procname: *const c_char) -> extern "C" fn();
+
+        pub fn eglInitialize(dpy: EGLDisplay, major: *mut EGLint, minor: *mut EGLint) -> EGLBoolean;
+
+        pub fn eglMakeCurrent(dpy: EGLDisplay, draw: EGLSurface,
+                              read: EGLSurface, ctx: EGLContext) -> EGLBoolean;
+
+        pub fn eglQueryAPI() -> EGLenum;
+
+        pub fn eglQueryContext(dpy: EGLDisplay, ctx: EGLContext,
+                               attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
+
+        pub fn eglQueryString(dpy: EGLDisplay, name: EGLint) -> *const c_char;
+
+        pub fn eglQuerySurface(dpy: EGLDisplay, surface: EGLSurface,
+                               attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
+
+        pub fn eglReleaseTexImage(dpy: EGLDisplay, surface: EGLSurface,
+                                  buffer: EGLint) -> EGLBoolean;
+
+        pub fn eglReleaseThread() -> EGLBoolean;
+
+        pub fn eglSurfaceAttrib(dpy: EGLDisplay, surface: EGLSurface,
+                                attribute: EGLint, value: EGLint) -> EGLBoolean;
+
+        pub fn eglSwapBuffers(dpy: EGLDisplay, surface: EGLSurface) -> EGLBoolean;
+
+        pub fn eglSwapInterval(dpy: EGLDisplay, interval: EGLint) -> EGLBoolean;
+
+        pub fn eglTerminate(dpy: EGLDisplay) -> EGLBoolean;
+
+        pub fn eglWaitClient() -> EGLBoolean;
+
+        pub fn eglWaitGL() -> EGLBoolean;
+
+        pub fn eglWaitNative(engine: EGLint) -> EGLBoolean;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,8 @@
 // | See the License for the specific language governing permissions and                           |
 // | limitations under the License.                                                                |
 // +-----------------------------------------------------------------------------------------------+
-// | Author: Sean Kerr <sean@metatomic.io>                                                         |
+// | Authors: Sean Kerr <sean@metatomic.io>                                                        |
+// |          Timothée Haudebourg <author@haudebourg.net>                                          |
 // +-----------------------------------------------------------------------------------------------+
 
 #![crate_name = "egl"]
@@ -33,7 +34,8 @@ use std::ffi::CString;
 use std::ptr;
 
 // system
-use khronos::khronos_int32_t;
+use khronos::{ khronos_int32_t,
+               khronos_utime_nanoseconds_t };
 
 use libc::{ c_uint,
             c_void,
@@ -46,23 +48,23 @@ use libc::{ c_uint,
 #[link(name = "EGL")]
 extern {}
 
-// -------------------------------------------------------------------------------------------------
-// GLOBAL TYPES
-// -------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+// EGL 1.0
+// ------------------------------------------------------------------------------------------------
 
 pub type EGLBoolean           = c_uint;
-pub type EGLClientBuffer      = *mut c_void;
+pub type EGLint               = khronos_int32_t;
+pub type EGLDisplay           = *mut c_void;
 pub type EGLConfig            = *mut c_void;
 pub type EGLContext           = *mut c_void;
-pub type EGLDisplay           = *mut c_void;
-pub type EGLenum              = c_uint;
-pub type EGLint               = khronos_int32_t;
-pub type EGLNativeDisplayType = *mut c_void;
 pub type EGLSurface           = *mut c_void;
+pub type EGLNativeDisplayType = *mut c_void;
 
-// -------------------------------------------------------------------------------------------------
-// ANDROID TYPES
-// -------------------------------------------------------------------------------------------------
+#[cfg(not(android))]
+pub type EGLNativePixmapType = *mut c_void;
+
+#[cfg(not(android))]
+pub type EGLNativeWindowType = *mut c_void;
 
 #[repr(C)]
 #[cfg(android)]
@@ -78,222 +80,76 @@ pub type EGLNativePixmapType = *mut egl_native_pixmap_t;
 #[cfg(android)]
 pub type EGLNativeWindowType = *mut android_native_window_t;
 
-// -------------------------------------------------------------------------------------------------
-// NON-ANDROID TYPES
-// -------------------------------------------------------------------------------------------------
-
-#[cfg(not(android))]
-pub type EGLNativePixmapType = *mut c_void;
-
-#[cfg(not(android))]
-pub type EGLNativeWindowType = *mut c_void;
-
-// -------------------------------------------------------------------------------------------------
-// STRUCTS
-// -------------------------------------------------------------------------------------------------
-
 pub struct EGLConfigList {
-    pub configs: EGLConfig,
+    pub configs: *mut EGLConfig,
     pub count:   int32_t
 }
 
-// -------------------------------------------------------------------------------------------------
-// CONSTANTS
-// -------------------------------------------------------------------------------------------------
-
-// EGL aliases
-pub const EGL_FALSE: EGLBoolean = 0;
-pub const EGL_TRUE:  EGLBoolean = 1;
-
-// out-of-band handle values
-pub const EGL_DEFAULT_DISPLAY: EGLNativeDisplayType = 0 as *mut c_void;
-pub const EGL_NO_CONTEXT:      EGLContext = 0 as *mut c_void;
-pub const EGL_NO_DISPLAY:      EGLDisplay = 0 as *mut c_void;
-pub const EGL_NO_SURFACE:      EGLSurface = 0 as *mut c_void;
-
-// out-of-band attribute value
-pub const EGL_DONT_CARE: EGLint = -1;
-
-// errors / GetError return values
-pub const EGL_SUCCESS:             EGLint = 0x3000;
-pub const EGL_NOT_INITIALIZED:     EGLint = 0x3001;
-pub const EGL_BAD_ACCESS:          EGLint = 0x3002;
-pub const EGL_BAD_ALLOC:           EGLint = 0x3003;
-pub const EGL_BAD_ATTRIBUTE:       EGLint = 0x3004;
-pub const EGL_BAD_CONFIG:          EGLint = 0x3005;
-pub const EGL_BAD_CONTEXT:         EGLint = 0x3006;
+pub const EGL_ALPHA_SIZE: EGLint = 0x3021;
+pub const EGL_BAD_ACCESS: EGLint = 0x3002;
+pub const EGL_BAD_ALLOC: EGLint = 0x3003;
+pub const EGL_BAD_ATTRIBUTE: EGLint = 0x3004;
+pub const EGL_BAD_CONFIG: EGLint = 0x3005;
+pub const EGL_BAD_CONTEXT: EGLint = 0x3006;
 pub const EGL_BAD_CURRENT_SURFACE: EGLint = 0x3007;
-pub const EGL_BAD_DISPLAY:         EGLint = 0x3008;
-pub const EGL_BAD_MATCH:           EGLint = 0x3009;
-pub const EGL_BAD_NATIVE_PIXMAP:   EGLint = 0x300A;
-pub const EGL_BAD_NATIVE_WINDOW:   EGLint = 0x300B;
-pub const EGL_BAD_PARAMETER:       EGLint = 0x300C;
-pub const EGL_BAD_SURFACE:         EGLint = 0x300D;
-pub const EGL_CONTEXT_LOST:        EGLint = 0x300E;  // EGL 1.1 - IMG_power_management
-
-// config attributes
-pub const EGL_BUFFER_SIZE:             EGLint = 0x3020;
-pub const EGL_ALPHA_SIZE:              EGLint = 0x3021;
-pub const EGL_BLUE_SIZE:               EGLint = 0x3022;
-pub const EGL_GREEN_SIZE:              EGLint = 0x3023;
-pub const EGL_RED_SIZE:                EGLint = 0x3024;
-pub const EGL_DEPTH_SIZE:              EGLint = 0x3025;
-pub const EGL_STENCIL_SIZE:            EGLint = 0x3026;
-pub const EGL_CONFIG_CAVEAT:           EGLint = 0x3027;
-pub const EGL_CONFIG_ID:               EGLint = 0x3028;
-pub const EGL_LEVEL:                   EGLint = 0x3029;
-pub const EGL_MAX_PBUFFER_HEIGHT:      EGLint = 0x302A;
-pub const EGL_MAX_PBUFFER_PIXELS:      EGLint = 0x302B;
-pub const EGL_MAX_PBUFFER_WIDTH:       EGLint = 0x302C;
-pub const EGL_NATIVE_RENDERABLE:       EGLint = 0x302D;
-pub const EGL_NATIVE_VISUAL_ID:        EGLint = 0x302E;
-pub const EGL_NATIVE_VISUAL_TYPE:      EGLint = 0x302F;
-pub const EGL_SAMPLES:                 EGLint = 0x3031;
-pub const EGL_SAMPLE_BUFFERS:          EGLint = 0x3032;
-pub const EGL_SURFACE_TYPE:            EGLint = 0x3033;
-pub const EGL_TRANSPARENT_TYPE:        EGLint = 0x3034;
-pub const EGL_TRANSPARENT_BLUE_VALUE:  EGLint = 0x3035;
-pub const EGL_TRANSPARENT_GREEN_VALUE: EGLint = 0x3036;
-pub const EGL_TRANSPARENT_RED_VALUE:   EGLint = 0x3037;
-pub const EGL_NONE:                    EGLint = 0x3038; // attrib list terminator
-pub const EGL_BIND_TO_TEXTURE_RGB:     EGLint = 0x3039;
-pub const EGL_BIND_TO_TEXTURE_RGBA:    EGLint = 0x303A;
-pub const EGL_MIN_SWAP_INTERVAL:       EGLint = 0x303B;
-pub const EGL_MAX_SWAP_INTERVAL:       EGLint = 0x303C;
-pub const EGL_LUMINANCE_SIZE:          EGLint = 0x303D;
-pub const EGL_ALPHA_MASK_SIZE:         EGLint = 0x303E;
-pub const EGL_COLOR_BUFFER_TYPE:       EGLint = 0x303F;
-pub const EGL_RENDERABLE_TYPE:         EGLint = 0x3040;
-pub const EGL_MATCH_NATIVE_PIXMAP:     EGLint = 0x3041;  // psseudo-attribute (not queryable)
-pub const EGL_CONFORMANT:              EGLint = 0x3042;
-
-// config attribute values
-pub const EGL_SLOW_CONFIG:           EGLint = 0x3050;  // CONFIG_CAVEAT value
-pub const EGL_NON_CONFORMANT_CONFIG: EGLint = 0x3051;  // CONFIG_CAVEAT value
-pub const EGL_TRANSPARENT_RGB:       EGLint = 0x3052;  // TRANSPARENT_TYPE value
-pub const EGL_RGB_BUFFER:            EGLint = 0x308E;  // COLOR_BUFFER_TYPE value
-pub const EGL_LUMINANCE_BUFFER:      EGLint = 0x308F;  // COLOR_BUFFER_TYPE value
-
-// more config attribute values, for TEXTURE_FORMAT
-pub const EGL_NO_TEXTURE:   EGLint = 0x305C;
-pub const EGL_TEXTURE_RGB:  EGLint = 0x305D;
-pub const EGL_TEXTURE_RGBA: EGLint = 0x305E;
-pub const EGL_TEXTURE_2D:   EGLint = 0x305F;
-
-// config attribute mask bits
-pub const EGL_PBUFFER_BIT:                 EGLint = 0x0001;  // SURFACE_TYPE mask bits
-pub const EGL_PIXMAP_BIT:                  EGLint = 0x0002;  // SURFACE_TYPE mask bits
-pub const EGL_WINDOW_BIT:                  EGLint = 0x0004;  // SURFACE_TYPE mask bits
-pub const EGL_VG_COLORSPACE_LINEAR_BIT:    EGLint = 0x0020;  // SURFACE_TYPE mask bits
-pub const EGL_VG_ALPHA_FORMAT_PRE_BIT:     EGLint = 0x0040;  // SURFACE_TYPE mask bits
-pub const EGL_MULTISAMPLE_RESOLVE_BOX_BIT: EGLint = 0x0200;  // SURFACE_TYPE mask bits
-pub const EGL_SWAP_BEHAVIOR_PRESERVED_BIT: EGLint = 0x0400;  // SURFACE_TYPE mask bits
-
-pub const EGL_OPENGL_ES_BIT:  EGLint = 0x0001; // RENDERABLE_TYPE mask bits
-pub const EGL_OPENVG_BIT:     EGLint = 0x0002; // RENDERABLE_TYPE mask bits
-pub const EGL_OPENGL_ES2_BIT: EGLint = 0x0004; // RENDERABLE_TYPE mask bits
-pub const EGL_OPENGL_BIT:     EGLint = 0x0008; // RENDERABLE_TYPE mask bits
-
-// QueryString targets
-pub const EGL_VENDOR:      EGLint = 0x3053;
-pub const EGL_VERSION:     EGLint = 0x3054;
-pub const EGL_EXTENSIONS:  EGLint = 0x3055;
-pub const EGL_CLIENT_APIS: EGLint = 0x308D;
-
-// QuerySurface / SurfaceAttrib / CreatePbufferSurface targets
-pub const EGL_HEIGHT:                EGLint = 0x3056;
-pub const EGL_WIDTH:                 EGLint = 0x3057;
-pub const EGL_LARGEST_PBUFFER:       EGLint = 0x3058;
-pub const EGL_TEXTURE_FORMAT:        EGLint = 0x3080;
-pub const EGL_TEXTURE_TARGET:        EGLint = 0x3081;
-pub const EGL_MIPMAP_TEXTURE:        EGLint = 0x3082;
-pub const EGL_MIPMAP_LEVEL:          EGLint = 0x3083;
-pub const EGL_RENDER_BUFFER:         EGLint = 0x3086;
-pub const EGL_VG_COLORSPACE:         EGLint = 0x3087;
-pub const EGL_VG_ALPHA_FORMAT:       EGLint = 0x3088;
-pub const EGL_HORIZONTAL_RESOLUTION: EGLint = 0x3090;
-pub const EGL_VERTICAL_RESOLUTION:   EGLint = 0x3091;
-pub const EGL_PIXEL_ASPECT_RATIO:    EGLint = 0x3092;
-pub const EGL_SWAP_BEHAVIOR:         EGLint = 0x3093;
-pub const EGL_MULTISAMPLE_RESOLVE:   EGLint = 0x3099;
-
-// RENDER_BUFFER values / BindTexImage / ReleaseTexImage buffer targets
-pub const EGL_BACK_BUFFER:   EGLint = 0x3084;
-pub const EGL_SINGLE_BUFFER: EGLint = 0x3085;
-
-// OpenVG color spaces */
-pub const EGL_VG_COLORSPACE_sRGB:   EGLint = 0x3089;  // VG_COLORSPACE value
-pub const EGL_VG_COLORSPACE_LINEAR: EGLint = 0x308A;  // VG_COLORSPACE value
-
-// OpenVG alpha formats
-pub const EGL_VG_ALPHA_FORMAT_NONPRE: EGLint = 0x308B; // ALPHA_FORMAT value
-pub const EGL_VG_ALPHA_FORMAT_PRE:    EGLint = 0x308C; // ALPHA_FORMAT value
-
-// constant scale factor by which fractional display resolutions & aspect ratio are scaled when
-// queried as integer values
-pub const EGL_DISPLAY_SCALING: EGLint = 10000;
-
-// unknown display resolution/aspect ratio
-pub const EGL_UNKNOWN: EGLint = -1;
-
-// back buffer swap behaviors
-pub const EGL_BUFFER_PRESERVED: EGLint = 0x3094; // SWAP_BEHAVIOR value
-pub const EGL_BUFFER_DESTROYED: EGLint = 0x3095; // SWAP_BEHAVIOR value
-
-// CreatePbufferFromClientBuffer buffer types
-pub const EGL_OPENVG_IMAGE: EGLint = 0x3096;
-
-// QueryContext targets
-pub const EGL_CONTEXT_CLIENT_TYPE: EGLint = 0x3097;
-
-// CreateContext attributes
-pub const EGL_CONTEXT_CLIENT_VERSION: EGLint = 0x3098;
-
-// multisample resolution behaviors
-pub const EGL_MULTISAMPLE_RESOLVE_DEFAULT: EGLint = 0x309A; // MULTISAMPLE_RESOLVE value
-pub const EGL_MULTISAMPLE_RESOLVE_BOX:     EGLint = 0x309B; // MULTISAMPLE_RESOLVE value
-
-// BindAPI/QueryAPI targets
-pub const EGL_OPENGL_ES_API: EGLenum = 0x30A0;
-pub const EGL_OPENVG_API:    EGLenum = 0x30A1;
-pub const EGL_OPENGL_API:    EGLenum = 0x30A2;
-
-// GetCurrentSurface targets
-pub const EGL_DRAW: EGLint = 0x3059;
-pub const EGL_READ: EGLint = 0x305A;
-
-// WaitNative engines
+pub const EGL_BAD_DISPLAY: EGLint = 0x3008;
+pub const EGL_BAD_MATCH: EGLint = 0x3009;
+pub const EGL_BAD_NATIVE_PIXMAP: EGLint = 0x300A;
+pub const EGL_BAD_NATIVE_WINDOW: EGLint = 0x300B;
+pub const EGL_BAD_PARAMETER: EGLint = 0x300C;
+pub const EGL_BAD_SURFACE: EGLint = 0x300D;
+pub const EGL_BLUE_SIZE: EGLint = 0x3022;
+pub const EGL_BUFFER_SIZE: EGLint = 0x3020;
+pub const EGL_CONFIG_CAVEAT: EGLint = 0x3027;
+pub const EGL_CONFIG_ID: EGLint = 0x3028;
 pub const EGL_CORE_NATIVE_ENGINE: EGLint = 0x305B;
-
-// EGL 1.2 tokens renamed for consistency in EGL 1.3
-pub const EGL_COLORSPACE:          EGLint = EGL_VG_COLORSPACE;
-pub const EGL_ALPHA_FORMAT:        EGLint = EGL_VG_ALPHA_FORMAT;
-pub const EGL_COLORSPACE_sRGB:     EGLint = EGL_VG_COLORSPACE_sRGB;
-pub const EGL_COLORSPACE_LINEAR:   EGLint = EGL_VG_COLORSPACE_LINEAR;
-pub const EGL_ALPHA_FORMAT_NONPRE: EGLint = EGL_VG_ALPHA_FORMAT_NONPRE;
-pub const EGL_ALPHA_FORMAT_PRE:    EGLint = EGL_VG_ALPHA_FORMAT_PRE;
-
-// -------------------------------------------------------------------------------------------------
-// FUNCTIONS
-// -------------------------------------------------------------------------------------------------
-
-pub fn bind_api(api: EGLenum) -> bool {
-    unsafe {
-        ffi::eglBindAPI(api) == EGL_TRUE
-    }
-}
-
-pub fn bind_tex_image(display: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> bool {
-    unsafe {
-        ffi::eglBindTexImage(display, surface, buffer) == EGL_TRUE
-    }
-}
+pub const EGL_DEPTH_SIZE: EGLint = 0x3025;
+pub const EGL_DONT_CARE: EGLint = -1;
+pub const EGL_DRAW: EGLint = 0x3059;
+pub const EGL_EXTENSIONS: EGLint = 0x3055;
+pub const EGL_FALSE: EGLBoolean = 0;
+pub const EGL_GREEN_SIZE: EGLint = 0x3023;
+pub const EGL_HEIGHT: EGLint = 0x3056;
+pub const EGL_LARGEST_PBUFFER: EGLint = 0x3058;
+pub const EGL_LEVEL: EGLint = 0x3029;
+pub const EGL_MAX_PBUFFER_HEIGHT: EGLint = 0x302A;
+pub const EGL_MAX_PBUFFER_PIXELS: EGLint = 0x302B;
+pub const EGL_MAX_PBUFFER_WIDTH: EGLint = 0x302C;
+pub const EGL_NATIVE_RENDERABLE: EGLint = 0x302D;
+pub const EGL_NATIVE_VISUAL_ID: EGLint = 0x302E;
+pub const EGL_NATIVE_VISUAL_TYPE: EGLint = 0x302F;
+pub const EGL_NONE: EGLint = 0x3038;
+pub const EGL_NON_CONFORMANT_CONFIG: EGLint = 0x3051;
+pub const EGL_NOT_INITIALIZED: EGLint = 0x3001;
+pub const EGL_NO_CONTEXT: EGLContext = 0 as EGLContext;
+pub const EGL_NO_DISPLAY: EGLDisplay = 0 as EGLDisplay;
+pub const EGL_NO_SURFACE: EGLSurface = 0 as EGLSurface;
+pub const EGL_PBUFFER_BIT: EGLint = 0x0001;
+pub const EGL_PIXMAP_BIT: EGLint = 0x0002;
+pub const EGL_READ: EGLint = 0x305A;
+pub const EGL_RED_SIZE: EGLint = 0x3024;
+pub const EGL_SAMPLES: EGLint = 0x3031;
+pub const EGL_SAMPLE_BUFFERS: EGLint = 0x3032;
+pub const EGL_SLOW_CONFIG: EGLint = 0x3050;
+pub const EGL_STENCIL_SIZE: EGLint = 0x3026;
+pub const EGL_SUCCESS: EGLint = 0x3000;
+pub const EGL_SURFACE_TYPE: EGLint = 0x3033;
+pub const EGL_TRANSPARENT_BLUE_VALUE: EGLint = 0x3035;
+pub const EGL_TRANSPARENT_GREEN_VALUE: EGLint = 0x3036;
+pub const EGL_TRANSPARENT_RED_VALUE: EGLint = 0x3037;
+pub const EGL_TRANSPARENT_RGB: EGLint = 0x3052;
+pub const EGL_TRANSPARENT_TYPE: EGLint = 0x3034;
+pub const EGL_TRUE: EGLBoolean = 1;
+pub const EGL_VENDOR: EGLint = 0x3053;
+pub const EGL_VERSION: EGLint = 0x3054;
+pub const EGL_WIDTH: EGLint = 0x3057;
+pub const EGL_WINDOW_BIT: EGLint = 0x0004;
 
 pub fn choose_config(display: EGLDisplay, attrib_list: &[EGLint],
                      config_size: EGLint) -> Option<EGLConfig> {
     unsafe {
         let mut config: EGLConfig = ptr::null_mut();
-        let mut count:  EGLint = 0;
+        let mut count:  EGLint = 0;;
 
         let attribs = if attrib_list.len() > 0 {
             attrib_list.as_ptr()
@@ -334,27 +190,6 @@ pub fn create_context(display: EGLDisplay, config: EGLConfig, share_context: EGL
 
         if !context.is_null() {
             Some(context)
-        } else {
-            None
-        }
-    }
-}
-
-pub fn create_pbuffer_from_client_buffer(display: EGLDisplay, buffer_type: EGLenum,
-                                         buffer: EGLClientBuffer, config: EGLConfig,
-                                         attrib_list: &[EGLint]) -> Option<EGLSurface> {
-    unsafe {
-        let attribs = if attrib_list.len() > 0 {
-            attrib_list.as_ptr()
-        } else {
-            ptr::null()
-        };
-
-        let surface = ffi::eglCreatePbufferFromClientBuffer(display, buffer_type, buffer, config,
-                                                            attribs);
-
-        if !surface.is_null() {
-            Some(surface)
         } else {
             None
         }
@@ -450,18 +285,6 @@ pub fn get_configs(display: EGLDisplay, config_size: EGLint) -> EGLConfigList {
     }
 }
 
-pub fn get_current_context() -> Option<EGLContext> {
-    unsafe {
-        let context = ffi::eglGetCurrentContext();
-
-        if !context.is_null() {
-            Some(context)
-        } else {
-            None
-        }
-    }
-}
-
 pub fn get_current_display() -> Option<EGLDisplay> {
     unsafe {
         let display = ffi::eglGetCurrentDisplay();
@@ -525,12 +348,6 @@ pub fn make_current(display: EGLDisplay, draw: EGLSurface,
     }
 }
 
-pub fn query_api() -> EGLenum {
-    unsafe {
-        ffi::eglQueryAPI()
-    }
-}
-
 pub fn query_context(display: EGLDisplay, ctx: EGLContext,
                      attribute: EGLint, value: &mut EGLint) -> bool {
     unsafe {
@@ -557,46 +374,15 @@ pub fn query_surface(display: EGLDisplay, surface: EGLSurface,
     }
 }
 
-pub fn release_tex_image(display: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> bool {
-    unsafe {
-        ffi::eglReleaseTexImage(display, surface, buffer) == EGL_TRUE
-    }
-}
-
-pub fn release_thread() -> bool {
-    unsafe {
-        ffi::eglReleaseThread() == EGL_TRUE
-    }
-}
-
-pub fn surface_attrib(display: EGLDisplay, surface: EGLSurface,
-                      attribute: EGLint, value: EGLint) -> bool {
-    unsafe {
-        ffi::eglSurfaceAttrib(display, surface, attribute, value) == EGL_TRUE
-    }
-}
-
 pub fn swap_buffers(display: EGLDisplay, surface: EGLSurface) -> bool {
     unsafe {
         ffi::eglSwapBuffers(display, surface) == EGL_TRUE
     }
 }
 
-pub fn swap_interval(display: EGLDisplay, interval: EGLint) -> bool {
-    unsafe {
-        ffi::eglSwapInterval(display, interval) == EGL_TRUE
-    }
-}
-
 pub fn terminate(display: EGLDisplay) -> bool {
     unsafe {
         ffi::eglTerminate(display) == EGL_TRUE
-    }
-}
-
-pub fn wait_client() -> bool {
-    unsafe {
-        ffi::eglWaitClient() == EGL_TRUE
     }
 }
 
@@ -612,12 +398,354 @@ pub fn wait_native(engine: EGLint) -> bool {
     }
 }
 
+// ------------------------------------------------------------------------------------------------
+// EGL 1.1
+// ------------------------------------------------------------------------------------------------
+
+pub const EGL_BACK_BUFFER: EGLint = 0x3084;
+pub const EGL_BIND_TO_TEXTURE_RGB: EGLint = 0x3039;
+pub const EGL_BIND_TO_TEXTURE_RGBA: EGLint = 0x303A;
+pub const EGL_CONTEXT_LOST: EGLint = 0x300E;
+pub const EGL_MIN_SWAP_INTERVAL: EGLint = 0x303B;
+pub const EGL_MAX_SWAP_INTERVAL: EGLint = 0x303C;
+pub const EGL_MIPMAP_TEXTURE: EGLint = 0x3082;
+pub const EGL_MIPMAP_LEVEL: EGLint = 0x3083;
+pub const EGL_NO_TEXTURE: EGLint = 0x305C;
+pub const EGL_TEXTURE_2D: EGLint = 0x305F;
+pub const EGL_TEXTURE_FORMAT: EGLint = 0x3080;
+pub const EGL_TEXTURE_RGB: EGLint = 0x305D;
+pub const EGL_TEXTURE_RGBA: EGLint = 0x305E;
+pub const EGL_TEXTURE_TARGET: EGLint = 0x3081;
+
+pub fn bind_tex_image(display: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> bool {
+    unsafe {
+        ffi::eglBindTexImage(display, surface, buffer) == EGL_TRUE
+    }
+}
+
+pub fn release_tex_image(display: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> bool {
+    unsafe {
+        ffi::eglReleaseTexImage(display, surface, buffer) == EGL_TRUE
+    }
+}
+
+pub fn surface_attrib(display: EGLDisplay, surface: EGLSurface,
+                      attribute: EGLint, value: EGLint) -> bool {
+    unsafe {
+        ffi::eglSurfaceAttrib(display, surface, attribute, value) == EGL_TRUE
+    }
+}
+
+pub fn swap_interval(display: EGLDisplay, interval: EGLint) -> bool {
+    unsafe {
+        ffi::eglSwapInterval(display, interval) == EGL_TRUE
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// EGL 1.2
+// ------------------------------------------------------------------------------------------------
+
+pub type EGLenum              = c_uint;
+pub type EGLClientBuffer      = *mut c_void;
+
+pub const EGL_ALPHA_FORMAT: EGLint = 0x3088;
+pub const EGL_ALPHA_FORMAT_NONPRE: EGLint = 0x308B;
+pub const EGL_ALPHA_FORMAT_PRE: EGLint = 0x308C;
+pub const EGL_ALPHA_MASK_SIZE: EGLint = 0x303E;
+pub const EGL_BUFFER_PRESERVED: EGLint = 0x3094;
+pub const EGL_BUFFER_DESTROYED: EGLint = 0x3095;
+pub const EGL_CLIENT_APIS: EGLint = 0x308D;
+pub const EGL_COLORSPACE: EGLint = 0x3087;
+pub const EGL_COLORSPACE_sRGB: EGLint = 0x3089;
+pub const EGL_COLORSPACE_LINEAR: EGLint = 0x308A;
+pub const EGL_COLOR_BUFFER_TYPE: EGLint = 0x303F;
+pub const EGL_CONTEXT_CLIENT_TYPE: EGLint = 0x3097;
+pub const EGL_DISPLAY_SCALING: EGLint = 10000;
+pub const EGL_HORIZONTAL_RESOLUTION: EGLint = 0x3090;
+pub const EGL_LUMINANCE_BUFFER: EGLint = 0x308F;
+pub const EGL_LUMINANCE_SIZE: EGLint = 0x303D;
+pub const EGL_OPENGL_ES_BIT: EGLint = 0x0001;
+pub const EGL_OPENVG_BIT: EGLint = 0x0002;
+pub const EGL_OPENGL_ES_API: EGLint = 0x30A0;
+pub const EGL_OPENVG_API: EGLint = 0x30A1;
+pub const EGL_OPENVG_IMAGE: EGLint = 0x3096;
+pub const EGL_PIXEL_ASPECT_RATIO: EGLint = 0x3092;
+pub const EGL_RENDERABLE_TYPE: EGLint = 0x3040;
+pub const EGL_RENDER_BUFFER: EGLint = 0x3086;
+pub const EGL_RGB_BUFFER: EGLint = 0x308E;
+pub const EGL_SINGLE_BUFFER: EGLint = 0x3085;
+pub const EGL_SWAP_BEHAVIOR: EGLint = 0x3093;
+pub const EGL_UNKNOWN: EGLint = -1;
+pub const EGL_VERTICAL_RESOLUTION: EGLint = 0x3091;
+
+pub fn bind_api(api: EGLenum) -> bool {
+    unsafe {
+        ffi::eglBindAPI(api) == EGL_TRUE
+    }
+}
+
+pub fn query_api() -> EGLenum {
+    unsafe {
+        ffi::eglQueryAPI()
+    }
+}
+
+pub fn create_pbuffer_from_client_buffer(display: EGLDisplay, buffer_type: EGLenum,
+                                         buffer: EGLClientBuffer, config: EGLConfig,
+                                         attrib_list: &[EGLint]) -> Option<EGLSurface> {
+    unsafe {
+        let attribs = if attrib_list.len() > 0 {
+            attrib_list.as_ptr()
+        } else {
+            ptr::null()
+        };
+
+        let surface = ffi::eglCreatePbufferFromClientBuffer(display, buffer_type, buffer, config,
+                                                            attribs);
+
+        if !surface.is_null() {
+            Some(surface)
+        } else {
+            None
+        }
+    }
+}
+
+pub fn release_thread() -> bool {
+    unsafe {
+        ffi::eglReleaseThread() == EGL_TRUE
+    }
+}
+
+pub fn wait_client() -> bool {
+    unsafe {
+        ffi::eglWaitClient() == EGL_TRUE
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// EGL 1.3
+// ------------------------------------------------------------------------------------------------
+
+pub const EGL_CONFORMANT: EGLint = 0x3042;
+pub const EGL_CONTEXT_CLIENT_VERSION: EGLint = 0x3098;
+pub const EGL_MATCH_NATIVE_PIXMAP: EGLint = 0x3041;
+pub const EGL_OPENGL_ES2_BIT: EGLint = 0x0004;
+pub const EGL_VG_ALPHA_FORMAT: EGLint = 0x3088;
+pub const EGL_VG_ALPHA_FORMAT_NONPRE: EGLint = 0x308B;
+pub const EGL_VG_ALPHA_FORMAT_PRE: EGLint = 0x308C;
+pub const EGL_VG_ALPHA_FORMAT_PRE_BIT: EGLint = 0x0040;
+pub const EGL_VG_COLORSPACE: EGLint = 0x3087;
+pub const EGL_VG_COLORSPACE_sRGB: EGLint = 0x3089;
+pub const EGL_VG_COLORSPACE_LINEAR: EGLint = 0x308A;
+pub const EGL_VG_COLORSPACE_LINEAR_BIT: EGLint = 0x0020;
+
+// ------------------------------------------------------------------------------------------------
+// EGL 1.4
+// ------------------------------------------------------------------------------------------------
+
+pub const EGL_DEFAULT_DISPLAY: EGLNativeDisplayType = 0 as EGLNativeDisplayType;
+pub const EGL_MULTISAMPLE_RESOLVE_BOX_BIT: EGLint = 0x0200;
+pub const EGL_MULTISAMPLE_RESOLVE: EGLint = 0x3099;
+pub const EGL_MULTISAMPLE_RESOLVE_DEFAULT: EGLint = 0x309A;
+pub const EGL_MULTISAMPLE_RESOLVE_BOX: EGLint = 0x309B;
+pub const EGL_OPENGL_API: EGLint = 0x30A2;
+pub const EGL_OPENGL_BIT: EGLint = 0x0008;
+pub const EGL_SWAP_BEHAVIOR_PRESERVED_BIT: EGLint = 0x0400;
+
+pub fn get_current_context() -> Option<EGLContext> {
+    unsafe {
+        let context = ffi::eglGetCurrentContext();
+
+        if !context.is_null() {
+            Some(context)
+        } else {
+            None
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// EGL 1.5
+// ------------------------------------------------------------------------------------------------
+
+pub type EGLSync              = *mut c_void;
+pub type EGLAttrib            = usize;
+pub type EGLTime              = khronos_utime_nanoseconds_t;
+pub type EGLImage             = *mut c_void;
+
+pub const EGL_CONTEXT_MAJOR_VERSION: EGLint = 0x3098;
+pub const EGL_CONTEXT_MINOR_VERSION: EGLint = 0x30FB;
+pub const EGL_CONTEXT_OPENGL_PROFILE_MASK: EGLint = 0x30FD;
+pub const EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY: EGLint = 0x31BD;
+pub const EGL_NO_RESET_NOTIFICATION: EGLint = 0x31BE;
+pub const EGL_LOSE_CONTEXT_ON_RESET: EGLint = 0x31BF;
+pub const EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT: EGLint = 0x00000001;
+pub const EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT: EGLint = 0x00000002;
+pub const EGL_CONTEXT_OPENGL_DEBUG: EGLint = 0x31B0;
+pub const EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE: EGLint = 0x31B1;
+pub const EGL_CONTEXT_OPENGL_ROBUST_ACCESS: EGLint = 0x31B2;
+pub const EGL_OPENGL_ES3_BIT: EGLint = 0x00000040;
+pub const EGL_CL_EVENT_HANDLE: EGLint = 0x309C;
+pub const EGL_SYNC_CL_EVENT: EGLint = 0x30FE;
+pub const EGL_SYNC_CL_EVENT_COMPLETE: EGLint = 0x30FF;
+pub const EGL_SYNC_PRIOR_COMMANDS_COMPLETE: EGLint = 0x30F0;
+pub const EGL_SYNC_TYPE: EGLint = 0x30F7;
+pub const EGL_SYNC_STATUS: EGLint = 0x30F1;
+pub const EGL_SYNC_CONDITION: EGLint = 0x30F8;
+pub const EGL_SIGNALED: EGLint = 0x30F2;
+pub const EGL_UNSIGNALED: EGLint = 0x30F3;
+pub const EGL_SYNC_FLUSH_COMMANDS_BIT: EGLint = 0x0001;
+pub const EGL_FOREVER: u64 = 0xFFFFFFFFFFFFFFFFu64;
+pub const EGL_TIMEOUT_EXPIRED: EGLint = 0x30F5;
+pub const EGL_CONDITION_SATISFIED: EGLint = 0x30F6;
+pub const EGL_NO_SYNC: EGLSync = 0 as EGLSync;
+pub const EGL_SYNC_FENCE: EGLint = 0x30F9;
+pub const EGL_GL_COLORSPACE: EGLint = 0x309D;
+pub const EGL_GL_COLORSPACE_SRGB: EGLint = 0x3089;
+pub const EGL_GL_COLORSPACE_LINEAR: EGLint = 0x308A;
+pub const EGL_GL_RENDERBUFFER: EGLint = 0x30B9;
+pub const EGL_GL_TEXTURE_2D: EGLint = 0x30B1;
+pub const EGL_GL_TEXTURE_LEVEL: EGLint = 0x30BC;
+pub const EGL_GL_TEXTURE_3D: EGLint = 0x30B2;
+pub const EGL_GL_TEXTURE_ZOFFSET: EGLint = 0x30BD;
+pub const EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_X: EGLint = 0x30B3;
+pub const EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_X: EGLint = 0x30B4;
+pub const EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Y: EGLint = 0x30B5;
+pub const EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Y: EGLint = 0x30B6;
+pub const EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Z: EGLint = 0x30B7;
+pub const EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Z: EGLint = 0x30B8;
+pub const EGL_IMAGE_PRESERVED: EGLint = 0x30D2;
+pub const EGL_NO_IMAGE: EGLImage = 0 as EGLImage;
+
+pub fn create_sync(dpy: EGLDisplay, ty: EGLenum, attrib_list: &[EGLAttrib]) -> Option<EGLSync> {
+    let attribs = if attrib_list.len() > 0 {
+        attrib_list.as_ptr()
+    } else {
+        ptr::null()
+    };
+
+    unsafe {
+        let sync = ffi::eglCreateSync(dpy, ty, attribs);
+        if sync.is_null() {
+            None
+        } else {
+            Some(sync)
+        }
+    }
+}
+
+pub fn destroy_sync(dpy: EGLDisplay, sync: EGLSync) -> bool {
+    unsafe {
+        ffi::eglDestroySync(dpy, sync) == EGL_TRUE
+    }
+}
+
+pub fn client_wait_sync(dpy: EGLDisplay, sync: EGLSync, flags: EGLint, timeout: EGLTime) -> EGLint {
+    unsafe {
+        ffi::eglClientWaitSync(dpy, sync, flags, timeout)
+    }
+}
+
+pub fn get_sync_attrib(dpy: EGLDisplay, sync: EGLSync, attribute: EGLint) -> Option<EGLAttrib> {
+    unsafe {
+        let mut value = 0;
+        if ffi::eglGetSyncAttrib(dpy, sync, attribute, &mut value as *mut EGLAttrib) == EGL_TRUE {
+            None
+        } else {
+            Some(value)
+        }
+    }
+}
+
+pub fn create_image(dpy: EGLDisplay, ctx: EGLContext, target: EGLenum, buffer: EGLClientBuffer, attrib_list: &[EGLAttrib]) -> Option<EGLImage> {
+    let attribs = if attrib_list.len() > 0 {
+        attrib_list.as_ptr()
+    } else {
+        ptr::null()
+    };
+
+    unsafe {
+        let image = ffi::eglCreateImage(dpy, ctx, target, buffer, attribs);
+        if image.is_null() {
+            None
+        } else {
+            Some(image)
+        }
+    }
+}
+
+pub fn destroy_image(dpy: EGLDisplay, image: EGLImage) -> bool {
+    unsafe {
+        ffi::eglDestroyImage(dpy, image) == EGL_TRUE
+    }
+}
+
+pub fn get_platform_display(platform: EGLenum, native_display: *mut c_void, attrib_list: &[EGLAttrib]) -> Option<EGLDisplay> {
+    let attribs = if attrib_list.len() > 0 {
+        attrib_list.as_ptr()
+    } else {
+        ptr::null()
+    };
+
+    unsafe {
+        let display = ffi::eglGetPlatformDisplay(platform, native_display, attribs);
+        if display.is_null() {
+            None
+        } else {
+            Some(display)
+        }
+    }
+}
+
+pub fn create_platform_window_surface(dpy: EGLDisplay, config: EGLConfig, native_window: *mut c_void, attrib_list: &[EGLAttrib]) -> Option<EGLSurface> {
+    let attribs = if attrib_list.len() > 0 {
+        attrib_list.as_ptr()
+    } else {
+        ptr::null()
+    };
+
+    unsafe {
+        let surface = ffi::eglCreatePlatformWindowSurface(dpy, config, native_window, attribs);
+        if surface.is_null() {
+            None
+        } else {
+            Some(surface)
+        }
+    }
+}
+
+pub fn create_platform_pixmap_surface(dpy: EGLDisplay, config: EGLConfig, native_pixmap: *mut c_void, attrib_list: &[EGLAttrib]) -> Option<EGLSurface> {
+    let attribs = if attrib_list.len() > 0 {
+        attrib_list.as_ptr()
+    } else {
+        ptr::null()
+    };
+
+    unsafe {
+        let surface = ffi::eglCreatePlatformPixmapSurface(dpy, config, native_pixmap, attribs);
+        if surface.is_null() {
+            None
+        } else {
+            Some(surface)
+        }
+    }
+}
+
+pub fn wait_sync(dpy: EGLDisplay, sync: EGLSync, flags: EGLint) -> bool {
+    unsafe {
+        ffi::eglWaitSync(dpy, sync, flags) == EGL_TRUE
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 // FFI
 // -------------------------------------------------------------------------------------------------
 
 mod ffi {
-    use libc::c_char;
+    use libc::{ c_char,
+                c_void };
 
     use super::{ EGLBoolean,
                  EGLClientBuffer,
@@ -629,94 +757,65 @@ mod ffi {
                  EGLNativeDisplayType,
                  EGLNativePixmapType,
                  EGLNativeWindowType,
-                 EGLSurface };
+                 EGLSurface,
+                 EGLAttrib,
+                 EGLSync,
+                 EGLTime,
+                 EGLImage };
 
     extern {
-        pub fn eglBindAPI(api: EGLenum) -> EGLBoolean;
-
-        pub fn eglBindTexImage(dpy: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> EGLBoolean;
-
-        pub fn eglChooseConfig(dpy: EGLDisplay, attrib_list: *const EGLint,
-                               configs: *mut EGLConfig, config_size: EGLint,
-                               num_config: *mut EGLint) -> EGLBoolean;
-
-        pub fn eglCopyBuffers(dpy: EGLDisplay, surface: EGLSurface,
-                              target: EGLNativePixmapType) -> EGLBoolean;
-
-        pub fn eglCreateContext(dpy: EGLDisplay, config: EGLConfig,
-                                share_context: EGLContext,
-                                attrib_list: *const EGLint) -> EGLContext;
-
-        pub fn eglCreatePbufferFromClientBuffer(dpy: EGLDisplay, buftype: EGLenum,
-                                                buffer: EGLClientBuffer, config: EGLConfig,
-                                                attrib_list: *const EGLint) -> EGLSurface;
-
-        pub fn eglCreatePbufferSurface(dpy: EGLDisplay, config: EGLConfig,
-                                       attrib_list: *const EGLint) -> EGLSurface;
-
-        pub fn eglCreatePixmapSurface(dpy: EGLDisplay, config: EGLConfig,
-                                      pixmap: EGLNativePixmapType,
-                                      attrib_list: *const EGLint) -> EGLSurface;
-
-        pub fn eglCreateWindowSurface(dpy: EGLDisplay, config: EGLConfig,
-                                      win: EGLNativeWindowType,
-                                      attrib_list: *const EGLint) -> EGLSurface;
-
+        // EGL 1.0
+        pub fn eglChooseConfig(dpy: EGLDisplay, attrib_list: *const EGLint, configs: *mut EGLConfig, config_size: EGLint, num_config: *mut EGLint) -> EGLBoolean;
+        pub fn eglCopyBuffers(dpy: EGLDisplay, surface: EGLSurface, target: EGLNativePixmapType) -> EGLBoolean;
+        pub fn eglCreateContext(dpy: EGLDisplay, config: EGLConfig, share_context: EGLContext, attrib_list: *const EGLint) -> EGLContext;
+        pub fn eglCreatePbufferSurface(dpy: EGLDisplay, config: EGLConfig, attrib_list: *const EGLint) -> EGLSurface;
+        pub fn eglCreatePixmapSurface(dpy: EGLDisplay, config: EGLConfig, pixmap: EGLNativePixmapType, attrib_list: *const EGLint) -> EGLSurface;
+        pub fn eglCreateWindowSurface(dpy: EGLDisplay, config: EGLConfig, win: EGLNativeWindowType, attrib_list: *const EGLint) -> EGLSurface;
         pub fn eglDestroyContext(dpy: EGLDisplay, ctx: EGLContext) -> EGLBoolean;
-
         pub fn eglDestroySurface(dpy: EGLDisplay, surface: EGLSurface) -> EGLBoolean;
-
-        pub fn eglGetConfigAttrib(dpy: EGLDisplay, config: EGLConfig,
-                                  attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
-
-        pub fn eglGetConfigs(dpy: EGLDisplay, configs: EGLConfig,
-                             config_size: EGLint, num_config: *mut EGLint) -> EGLBoolean;
-
-        pub fn eglGetCurrentContext() -> EGLContext;
-
+        pub fn eglGetConfigAttrib(dpy: EGLDisplay, config: EGLConfig, attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
+        pub fn eglGetConfigs(dpy: EGLDisplay, configs: *mut EGLConfig, config_size: EGLint, num_config: *mut EGLint) -> EGLBoolean;
         pub fn eglGetCurrentDisplay() -> EGLDisplay;
-
         pub fn eglGetCurrentSurface(readdraw: EGLint) -> EGLSurface;
-
         pub fn eglGetDisplay(display_id: EGLNativeDisplayType) -> EGLDisplay;
-
         pub fn eglGetError() -> EGLint;
-
         pub fn eglGetProcAddress(procname: *const c_char) -> extern "C" fn();
-
         pub fn eglInitialize(dpy: EGLDisplay, major: *mut EGLint, minor: *mut EGLint) -> EGLBoolean;
-
-        pub fn eglMakeCurrent(dpy: EGLDisplay, draw: EGLSurface,
-                              read: EGLSurface, ctx: EGLContext) -> EGLBoolean;
-
-        pub fn eglQueryAPI() -> EGLenum;
-
-        pub fn eglQueryContext(dpy: EGLDisplay, ctx: EGLContext,
-                               attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
-
+        pub fn eglMakeCurrent(dpy: EGLDisplay, draw: EGLSurface, read: EGLSurface, ctx: EGLContext) -> EGLBoolean;
+        pub fn eglQueryContext(dpy: EGLDisplay, ctx: EGLContext, attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
         pub fn eglQueryString(dpy: EGLDisplay, name: EGLint) -> *const c_char;
-
-        pub fn eglQuerySurface(dpy: EGLDisplay, surface: EGLSurface,
-                               attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
-
-        pub fn eglReleaseTexImage(dpy: EGLDisplay, surface: EGLSurface,
-                                  buffer: EGLint) -> EGLBoolean;
-
-        pub fn eglReleaseThread() -> EGLBoolean;
-
-        pub fn eglSurfaceAttrib(dpy: EGLDisplay, surface: EGLSurface,
-                                attribute: EGLint, value: EGLint) -> EGLBoolean;
-
+        pub fn eglQuerySurface(dpy: EGLDisplay, surface: EGLSurface, attribute: EGLint, value: *mut EGLint) -> EGLBoolean;
         pub fn eglSwapBuffers(dpy: EGLDisplay, surface: EGLSurface) -> EGLBoolean;
+        pub fn eglTerminate(dpy: EGLDisplay) -> EGLBoolean;
+        pub fn eglWaitGL() -> EGLBoolean;
+        pub fn eglWaitNative(engine: EGLint) -> EGLBoolean;
 
+        // EGL 1.1
+        pub fn eglBindTexImage(dpy: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> EGLBoolean;
+        pub fn eglReleaseTexImage(dpy: EGLDisplay, surface: EGLSurface, buffer: EGLint) -> EGLBoolean;
+        pub fn eglSurfaceAttrib(dpy: EGLDisplay, surface: EGLSurface, attribute: EGLint, value: EGLint) -> EGLBoolean;
         pub fn eglSwapInterval(dpy: EGLDisplay, interval: EGLint) -> EGLBoolean;
 
-        pub fn eglTerminate(dpy: EGLDisplay) -> EGLBoolean;
-
+        // EGL 1.2
+        pub fn eglBindAPI(api: EGLenum) -> EGLBoolean;
+        pub fn eglQueryAPI() -> EGLenum;
+        pub fn eglCreatePbufferFromClientBuffer(dpy: EGLDisplay, buftype: EGLenum, buffer: EGLClientBuffer, config: EGLConfig, attrib_list: *const EGLint) -> EGLSurface;
+        pub fn eglReleaseThread() -> EGLBoolean;
         pub fn eglWaitClient() -> EGLBoolean;
 
-        pub fn eglWaitGL() -> EGLBoolean;
+        // EGL 1.4
+        pub fn eglGetCurrentContext() -> EGLContext;
 
-        pub fn eglWaitNative(engine: EGLint) -> EGLBoolean;
+        // EGL 1.5
+        pub fn eglCreateSync(dpy: EGLDisplay, type_: EGLenum, attrib_list: *const EGLAttrib) -> EGLSync;
+        pub fn eglDestroySync(dpy: EGLDisplay, sync: EGLSync) -> EGLBoolean;
+        pub fn eglClientWaitSync(dpy: EGLDisplay, sync: EGLSync, flags: EGLint, timeout: EGLTime) -> EGLint;
+        pub fn eglGetSyncAttrib(dpy: EGLDisplay, sync: EGLSync, attribute: EGLint, value: *mut EGLAttrib) -> EGLBoolean;
+        pub fn eglCreateImage(dpy: EGLDisplay, ctx: EGLContext, target: EGLenum, buffer: EGLClientBuffer, attrib_list: *const EGLAttrib) -> EGLImage;
+        pub fn eglDestroyImage(dpy: EGLDisplay, image: EGLImage) -> EGLBoolean;
+        pub fn eglGetPlatformDisplay(platform: EGLenum, native_display: *mut c_void, attrib_list: *const EGLAttrib) -> EGLDisplay;
+        pub fn eglCreatePlatformWindowSurface(dpy: EGLDisplay, config: EGLConfig, native_window: *mut c_void, attrib_list: *const EGLAttrib) -> EGLSurface;
+        pub fn eglCreatePlatformPixmapSurface(dpy: EGLDisplay, config: EGLConfig, native_pixmap: *mut c_void, attrib_list: *const EGLAttrib) -> EGLSurface;
+        pub fn eglWaitSync(dpy: EGLDisplay, sync: EGLSync, flags: EGLint) -> EGLBoolean;
     }
 }


### PR DESCRIPTION
By default cargo only uses the `-lEGL` flag to link against the EGL library and assume `ld` will find it. This is not the case on some platforms. I'm using the nix package manager on nixos, and libEGL cannot be found without using `pkg_config`.
In this PR I've added a new `build.rs` script that will invoke `pkg_config` at compile time. I've tested it on nixos and it does the job.